### PR TITLE
fix(sdk): add analyzer reference for source generators

### DIFF
--- a/src/CodingWithCalvin.VsixSdk/Sdk/Sdk.Vsix.props
+++ b/src/CodingWithCalvin.VsixSdk/Sdk/Sdk.Vsix.props
@@ -5,6 +5,15 @@
     VSIX-specific properties. Can be imported standalone or as part of the full SDK.
   -->
 
+  <!--
+    Include source generators from the SDK package.
+    The analyzers folder is at the package root, parallel to the Sdk folder.
+  -->
+  <ItemGroup>
+    <Analyzer Include="$(MSBuildThisFileDirectory)..\analyzers\dotnet\cs\CodingWithCalvin.VsixSdk.Generators.dll"
+              Condition="Exists('$(MSBuildThisFileDirectory)..\analyzers\dotnet\cs\CodingWithCalvin.VsixSdk.Generators.dll')" />
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- Identify that this SDK is in use -->
     <UsingCodingWithCalvinVsixSdk>true</UsingCodingWithCalvinVsixSdk>


### PR DESCRIPTION
## Summary
- Add explicit Analyzer item reference for the source generators DLL
- MSBuild SDK packages don't automatically pick up analyzers from the conventional path
- Fixes issue where VsixInfo and VSCT generated files were not being created