### PR TITLE
feat(generators): add string constant for top-level VSCT GUIDs

### DIFF
--- a/src/CodingWithCalvin.VsixSdk.Generators/VsctGuidsGenerator.cs
+++ b/src/CodingWithCalvin.VsixSdk.Generators/VsctGuidsGenerator.cs
@@ -160,9 +160,10 @@ public class VsctGuidsGenerator : IIncrementalGenerator
         {
             if (guidSymbol.IdSymbols.Count == 0)
             {
-                // Simple GUID constant
+                // Simple GUID constant with both string and Guid versions
                 sb.AppendLine($"        /// <summary>GUID: {{{guidSymbol.Value}}}</summary>");
-                sb.AppendLine($"        public static readonly Guid {guidSymbol.Name} = new Guid(\"{guidSymbol.Value}\");");
+                sb.AppendLine($"        public const string {guidSymbol.Name}String = \"{guidSymbol.Value}\";");
+                sb.AppendLine($"        public static readonly Guid {guidSymbol.Name} = new Guid({guidSymbol.Name}String);");
                 sb.AppendLine();
             }
             else


### PR DESCRIPTION
## Summary
- Top-level GUIDs (those without IDSymbols) now generate both a string constant and a Guid field
- This matches the behavior of command set GUIDs which already have `GuidString` and `Guid` members

**Before:**
```csharp
public static readonly Guid guidSamplePackage = new Guid("...");
```

**After:**
```csharp
public const string guidSamplePackageString = "...";
public static readonly Guid guidSamplePackage = new Guid(guidSamplePackageString);
```

## Test plan
- [x] Build generators project
- [x] Verify sample project generates updated VSCT code