### PR TITLE
fix(workflow): update contributors workflow

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -2,39 +2,10 @@ name: Update Contributors
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Run daily at midnight UTC
-  workflow_dispatch:  # Allow manual trigger
+    - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   contributors:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.CONTRIBUTORS_TOKEN }}
-
-      - name: Update contributors
-        env:
-          GH_TOKEN: ${{ secrets.CONTRIBUTORS_TOKEN }}
-        run: |
-          # Fetch contributors from GitHub API (exclude bots) - markdown format
-          contributors=$(gh api repos/CodingWithCalvin/VsixSdk/contributors --paginate --jq '.[] | select(.type != "Bot") | select(.login | test("\\[bot\\]$") | not) | "[![\(.login)](\(.avatar_url)&s=64)](\(.html_url))"' | tr '\n' ' ')
-
-          # Build the contributors section
-          contrib_section="<!-- readme: contributors -start -->
-$contributors
-<!-- readme: contributors -end -->"
-
-          # Update README between the markers
-          awk -v contrib="$contrib_section" '
-            /<!-- readme: contributors -start -->/{found=1; print contrib; next}
-            /<!-- readme: contributors -end -->/{found=0; next}
-            !found{print}
-          ' README.md > README.tmp && mv README.tmp README.md
-
-      - name: Commit and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md
-          git diff --staged --quiet || (git commit -m "docs: update contributors [skip ci]" && git push)
+    uses: CodingWithCalvin/.github/.github/workflows/contributors.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Use `${{ github.repository }}` instead of hardcoded repo name
- Include issue authors whose issues were closed by merged PRs
- Build contributor markdown with individual user lookups
- Match VSToolbox workflow implementation

## Test plan

- [ ] Manually trigger the workflow via workflow_dispatch
- [ ] Verify contributor avatars appear in README