### PR TITLE
chore: sync license format

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Coding With Calvin
+Copyright (c) 2025 Calvin Allen / Coding With Calvin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Sync LICENSE to standard format: `Copyright (c) <year> Calvin Allen / Coding With Calvin`