### PR TITLE
ci(workflow): add path filters to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'samples/**'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'samples/**'
+      - '.github/workflows/ci.yml'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
Add path filters to the CI workflow to prevent unnecessary builds when non-code files change.

## Changes
Only trigger builds when relevant files change:
- `src/**` - SDK and template source code
- `samples/**` - Sample extension code
- `.github/workflows/ci.yml` - Workflow itself

## Why
Documentation changes (like CLAUDE.md, README.md) were triggering full CI builds unnecessarily. This change ensures builds only run when actual source code changes.