### PR TITLE
chore(ci): rename workflows for consistency (ci->build, release->publish)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build
 
 on:
   push:
@@ -6,13 +6,13 @@ on:
     paths:
       - 'src/**'
       - 'samples/**'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/build.yml'
   pull_request:
     branches: [main]
     paths:
       - 'src/**'
       - 'samples/**'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/build.yml'
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Publish
 
 on:
   push:


### PR DESCRIPTION
## Summary
Rename workflow files to match Otel4Vsix naming convention for consistency across NuGet package repos.

## Changes
- `ci.yml` → `build.yml` (also updated workflow name from "CI" to "Build")
- `release.yml` → `publish.yml` (also updated workflow name from "Release" to "Publish")
- Updated self-references in path triggers