### PR TITLE
docs: add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0] - 2025-12-30
+
+### Added
+
+- String constant generation for top-level VSCT GUIDs
+- Implicit Microsoft.VSSDK.BuildTools package reference
+
+### Changed
+
+- Removed publish manifest generation (refactored for simplicity)
+
+## [0.2.0] - 2025-12-30
+
+### Added
+
+- Publish manifest generation and source generators
+- Analyzer reference for source generators
+
+### Fixed
+
+- Release workflow updated for moved solution location
+
+### Changed
+
+- README refreshed with emojis and reorganized sections
+- README badges updated to for-the-badge style
+
+[Unreleased]: https://github.com/CodingWithCalvin/VsixSdk/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/CodingWithCalvin/VsixSdk/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/CodingWithCalvin/VsixSdk/releases/tag/v0.2.0


### PR DESCRIPTION
## Summary
Add CHANGELOG.md following Keep a Changelog format for consistency with Otel4Vsix.

## Contents
- Documents v0.2.0 and v0.3.0 releases
- Includes Unreleased section for tracking upcoming changes
- Links to GitHub release comparisons

Note: This serves as a curated, permanent record alongside auto-generated release notes from conventional commits.