### PR TITLE
fix(sdk): escape backslashes in launchSettings.json generation

### DIFF
--- a/src/CodingWithCalvin.VsixSdk/Sdk/Sdk.Vsix.targets
+++ b/src/CodingWithCalvin.VsixSdk/Sdk/Sdk.Vsix.targets
@@ -146,11 +146,13 @@
           Condition="'$(BuildingInsideVisualStudio)' == 'true' and '$(DevEnvDir)' != '' and !Exists('$(MSBuildProjectDirectory)\Properties\launchSettings.json')">
 
     <PropertyGroup>
+      <!-- Escape backslashes for JSON -->
+      <_DevEnvDirEscaped>$([System.String]::Copy('$(DevEnvDir)').Replace('\','\\'))</_DevEnvDirEscaped>
       <_LaunchSettingsContent><![CDATA[{
   "profiles": {
-    "Start Experimental Instance": {
+    "Debug Extension": {
       "commandName": "Executable",
-      "executablePath": "$(DevEnvDir)devenv.exe",
+      "executablePath": "$(_DevEnvDirEscaped)devenv.exe",
       "commandLineArgs": "/rootSuffix Exp"
     }
   }


### PR DESCRIPTION
## Summary

- Escape backslashes in `$(DevEnvDir)` path when generating `launchSettings.json` to produce valid JSON
- Rename launch profile from "Start Experimental Instance" to "Debug Extension"

Closes #25