### PR TITLE
feat(sdk): auto-include imagemanifest and ContentManifest.json files

### DIFF
--- a/src/CodingWithCalvin.VsixSdk/Sdk/Sdk.Vsix.targets
+++ b/src/CodingWithCalvin.VsixSdk/Sdk/Sdk.Vsix.targets
@@ -34,6 +34,21 @@
       <DependentUpon>VSPackage.resx</DependentUpon>
     </EmbeddedResource>
 
+    <!-- Include Image Manifest files for VS Image Service -->
+    <ImageManifest Include="**/*.imagemanifest"
+                   Condition="'$(EnableDefaultImageManifestItems)' != 'false'"
+                   Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </ImageManifest>
+
+    <!-- Include Content Manifest files -->
+    <Content Include="**/ContentManifest.json"
+             Condition="'$(EnableDefaultContentManifestItems)' != 'false'"
+             Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- Add automatic inclusion of `.imagemanifest` files as `ImageManifest` items
- Add automatic inclusion of `ContentManifest.json` files as `Content` items with `IncludeInVSIX=true`
- Both can be disabled via `EnableDefaultImageManifestItems=false` or `EnableDefaultContentManifestItems=false`

## Details

This extends the SDK's auto-include feature to cover two additional VS extension file types:

### Image Manifests (`.imagemanifest`)
Used by the VS Image Service for custom images. Files are automatically included in the VSIX.

### Content Manifests (`ContentManifest.json`)
Used for VS extension content registration. Files are included in VSIX and copied to output.

Closes #31