### PR TITLE
feat(sdk): auto-include imagemanifest and ContentManifest.json files

### DIFF
--- a/src/CodingWithCalvin.VsixSdk/Sdk/Sdk.Vsix.props
+++ b/src/CodingWithCalvin.VsixSdk/Sdk/Sdk.Vsix.props
@@ -80,6 +80,12 @@
       Source generators already include them - having them on disk is for visibility only
     -->
     <DefaultItemExcludes>$(DefaultItemExcludes);Generated\**</DefaultItemExcludes>
+
+    <!--
+      Exclude VSPackage.resx from default EmbeddedResource includes
+      The SDK adds these with special metadata (MergeWithCTO) in targets
+    -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);**/VSPackage.resx;**/VSPackage.*.resx</DefaultItemExcludes>
   </PropertyGroup>
 
   <!-- F5 Debugging Configuration -->


### PR DESCRIPTION
## Summary
- Add automatic inclusion of `.imagemanifest` files as `ImageManifest` items
- Add automatic inclusion of `ContentManifest.json` files as `Content` items with `IncludeInVSIX=true`
- Fix duplicate EmbeddedResource error for VSPackage.resx files

## Details

### Image Manifests (`.imagemanifest`)
Used by the VS Image Service for custom images. Files are automatically included in the VSIX.

### Content Manifests (`ContentManifest.json`)
Used for VS extension content registration. Files are included in VSIX and copied to output.

### VSPackage.resx Fix
Excludes `VSPackage.resx` patterns from `DefaultItemExcludes` to prevent duplicate EmbeddedResource items. The SDK adds these with special `MergeWithCTO` metadata.

## Properties
- `EnableDefaultImageManifestItems=false` - Disable imagemanifest auto-include
- `EnableDefaultContentManifestItems=false` - Disable ContentManifest.json auto-include

Closes #31