### PR TITLE
fix(sdk): exclude template folders from default compilation

### DIFF
--- a/src/CodingWithCalvin.VsixSdk/Sdk/Sdk.Vsix.Templates.props
+++ b/src/CodingWithCalvin.VsixSdk/Sdk/Sdk.Vsix.Templates.props
@@ -16,6 +16,13 @@
     <!-- Default folders for template discovery -->
     <VsixProjectTemplatesFolder Condition="'$(VsixProjectTemplatesFolder)' == ''">ProjectTemplates</VsixProjectTemplatesFolder>
     <VsixItemTemplatesFolder Condition="'$(VsixItemTemplatesFolder)' == ''">ItemTemplates</VsixItemTemplatesFolder>
+
+    <!--
+      Exclude template folders from default compilation.
+      Template files contain VS template placeholders ($safeprojectname$, etc.)
+      that are not valid C# and should not be compiled as part of the extension.
+    -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);$(VsixProjectTemplatesFolder)\**;$(VsixItemTemplatesFolder)\**</DefaultItemExcludes>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
## Summary
Exclude `ProjectTemplates/` and `ItemTemplates/` folders from default compilation.

## Problem
Template files contain VS template placeholders (`$safeprojectname$`, `$guid1$`, etc.) that are not valid C# syntax. When these folders are in a VSIX project, the .NET SDK tries to compile them, causing build errors.

## Solution
Add the template folders to `DefaultItemExcludes` in `Sdk.Vsix.Templates.props`:
```xml
<DefaultItemExcludes>$(DefaultItemExcludes);$(VsixProjectTemplatesFolder)\**;$(VsixItemTemplatesFolder)\**</DefaultItemExcludes>
```

This uses the configurable folder properties, so custom folder locations are also excluded.