### PR TITLE
fix(sdk): fix VsixTemplateReference path computation

### DIFF
--- a/src/CodingWithCalvin.VsixSdk/Sdk/Sdk.Vsix.Templates.targets
+++ b/src/CodingWithCalvin.VsixSdk/Sdk/Sdk.Vsix.Templates.targets
@@ -70,11 +70,17 @@
         <_ZipOutputPath>$(_VsixTemplateIntermediateOutputPath)ItemTemplates\%(VsixItemTemplate.TargetSubPath)</_ZipOutputPath>
       </VsixItemTemplate>
 
-      <!-- Compute paths for template references -->
+      <!-- Compute paths for template references - Step 1: Get directory and folder name -->
       <VsixTemplateReference>
         <_ReferencedProjectDir>$([System.IO.Path]::GetDirectoryName('%(Identity)'))</_ReferencedProjectDir>
-        <_FullTemplatePath>%(VsixTemplateReference._ReferencedProjectDir)\%(VsixTemplateReference.TemplatePath)</_FullTemplatePath>
         <_TemplateFolderName>$([System.IO.Path]::GetFileName('%(VsixTemplateReference.TemplatePath)'))</_TemplateFolderName>
+      </VsixTemplateReference>
+    </ItemGroup>
+
+    <!-- Step 2: Compute full path and zip info using metadata from Step 1 -->
+    <ItemGroup>
+      <VsixTemplateReference>
+        <_FullTemplatePath>%(VsixTemplateReference._ReferencedProjectDir)\%(VsixTemplateReference.TemplatePath)</_FullTemplatePath>
         <_ZipFileName>%(VsixTemplateReference._TemplateFolderName).zip</_ZipFileName>
         <_ZipOutputPath Condition="'%(VsixTemplateReference.TemplateType)' == 'Project'">$(_VsixTemplateIntermediateOutputPath)ProjectTemplates\%(VsixTemplateReference.TargetSubPath)</_ZipOutputPath>
         <_ZipOutputPath Condition="'%(VsixTemplateReference.TemplateType)' == 'Item'">$(_VsixTemplateIntermediateOutputPath)ItemTemplates\%(VsixTemplateReference.TargetSubPath)</_ZipOutputPath>


### PR DESCRIPTION
## Summary
Fix the `VsixTemplateReference` path computation bug that caused templates from referenced projects to fail zipping.

## Problem
MSBuild cannot reference metadata that is set in the same `ItemGroup` update. The original code tried to set `_ReferencedProjectDir` and immediately use it to compute `_FullTemplatePath` in the same update, resulting in an empty/incorrect path.

## Solution
Split the metadata computation into two separate `ItemGroup` updates:
- **Step 1**: Compute `_ReferencedProjectDir` and `_TemplateFolderName`
- **Step 2**: Use those values to compute `_FullTemplatePath`, `_ZipFileName`, and `_ZipOutputPath`

## Testing
Verified locally that `VsixTemplateReference` now correctly resolves paths like:
```
..\E2E.Templates.SharedSource\Templates\SharedProject
```
instead of the broken:
```
C:\Templates\SharedProject
```

Closes #37